### PR TITLE
Issue with reopening Websocket after Idle 10m

### DIFF
--- a/UI/src/app/services/websocket.service.ts
+++ b/UI/src/app/services/websocket.service.ts
@@ -31,7 +31,6 @@ export class WebsocketService {
         console.debug("Websocket connection closed");
         closeSubscriber.next();
         closeSubscriber.complete();
-        observer.complete();
       };
 
       this.ws.onopen = event => {


### PR DESCRIPTION
There is non need for this line in websocket.service.ts as it also prevent the Observable from subscribing again which means the websocket is reopened but the frontend does not process it no more, there might be a better way of doing this but removing this line worked fine,

observer.complete();

I am no Angular expert, but removing this line worked fine in my deployment here

https://eu-west-3-amer-demo.auth.eu-west-3.amazoncognito.com/login?client_id=3uouf490c5u4mfej54igv25am9&response_type=token&redirect_uri=https://d17sdmhwxn0gs2.cloudfront.net/callback

On another note, there seems to be an issue with the way https://github.com/pladaria/reconnecting-websocket is used in reconnecting-websocket and in principle allows for reconnecting a closed socket with the option startClosed which defaults to false and even changing it to true does nothing , the only thing that worked was removing observer.complete(); from websocket.service.ts

To simulate idle timeout , I do not wait 10 minutes I just remove the connection from the API Gateway Websocket which is detected as websocket closed in the frontend

Example :

aws apigatewaymanagementapi delete-connection --endpoint-url https://***********.execute-api.eu-west-3.amazonaws.com/wss --connection-id CmGXUcpYiGYCGBA=